### PR TITLE
Remove shellcheck SC1117 error supression

### DIFF
--- a/add-ssh-connection
+++ b/add-ssh-connection
@@ -74,8 +74,6 @@ function generate_key()
 
 function install_local_key()
 {
-    # TODO: #5
-    # shellcheck disable=SC1117
     if ! printf "Host %s\n    HostName %s\n    User %s\n    IdentityFile %s\n    PreferredAuthentications publickey\n\n" "$name" "$ip_address" "$USER" "$private_key" >> "$HOME/.ssh/config"; then
         abort "local SSH key installation failure"
     fi

--- a/configure
+++ b/configure
@@ -131,8 +131,6 @@ function generate_and_install_github_ssh_key()
         abort "GitHub SSH key generation failure"
     fi
 
-    # TODO: #5
-    # shellcheck disable=SC1117
     if ! printf "Host github.com\n    User apcountryman\n    IdentityFile %s\n    PreferredAuthentications publickey\n\n" "$key" > "$HOME/.ssh/config"; then
         abort "GitHub SSH key installation failure"
     fi


### PR DESCRIPTION
Resolves #89.

shellcheck SC1117 triggered on harmless printf format strings which led
to the check being removed after version 0.5 (see
https://github.com/koalaman/shellcheck/wiki/SC1117). Ubuntu 20.04 ships
with shellcheck 0.7.0 so suppression of this error is no longer
required.